### PR TITLE
Add tests and CI for markitdown-ext

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install package
+        run: pip install -e . --no-deps
+      - name: Run tests
+        run: pytest -vv

--- a/markitdown_ext/cli.py
+++ b/markitdown_ext/cli.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+import argparse
+import os
 import sys
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Delegate to the upstream markitdown package."""
+    """Convert a PDF to Markdown and persist attachments."""
     if argv is None:
         argv = sys.argv[1:]
 
-    from markitdown.__main__ import main as upstream_main
+    parser = argparse.ArgumentParser(prog="markitdownx")
+    parser.add_argument("input_pdf")
+    parser.add_argument("output_md")
+    args = parser.parse_args(argv)
 
-    upstream_main(argv)
+    from markitdown import MarkItDown
+
+    md = MarkItDown()
+    result = md.convert(args.input_pdf, args.output_md)
+
+    attachments = getattr(result, "attachments", {})
+    if attachments:
+        assets_dir = os.path.splitext(args.output_md)[0] + "_assets"
+        os.makedirs(assets_dir, exist_ok=True)
+        for name, data in attachments.items():
+            with open(os.path.join(assets_dir, name), "wb") as f:
+                f.write(data)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-import types
 import sys
+from types import SimpleNamespace
 from pathlib import Path
 
 import markitdown_ext.cli as cli
@@ -22,8 +22,7 @@ def test_cli_saves_assets(tmp_path, monkeypatch):
             Path(output_md_path).write_text("dummy")
             return FakeResult()
 
-    fake_mod = types.SimpleNamespace(MarkItDown=FakeMarkItDown)
-    monkeypatch.setitem(sys.modules, "markitdown", fake_mod)
+    monkeypatch.setitem(sys.modules, "markitdown", SimpleNamespace(MarkItDown=FakeMarkItDown))
 
     cli.main([str(pdf), str(output_md)])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import types
+import sys
+from pathlib import Path
+
+import markitdown_ext.cli as cli
+
+
+def test_cli_saves_assets(tmp_path, monkeypatch):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    output_md = tmp_path / "out.md"
+
+    attachments = {"file1.txt": b"hello", "image.png": b"\x89PNG\r\n"}
+
+    class FakeResult:
+        def __init__(self):
+            self.attachments = attachments
+
+    class FakeMarkItDown:
+        def convert(self, input_pdf, output_md_path):
+            assert Path(input_pdf) == pdf
+            Path(output_md_path).write_text("dummy")
+            return FakeResult()
+
+    fake_mod = types.SimpleNamespace(MarkItDown=FakeMarkItDown)
+    monkeypatch.setitem(sys.modules, "markitdown", fake_mod)
+
+    cli.main([str(pdf), str(output_md)])
+
+    assets_dir = tmp_path / "out_assets"
+    assert assets_dir.is_dir()
+    for name, data in attachments.items():
+        assert (assets_dir / name).read_bytes() == data
+    assert output_md.is_file()


### PR DESCRIPTION
## Summary
- enhance CLI to persist MarkItDown attachments to `<output>_assets`
- add pytest coverage for CLI behaviour
- run pytest on push via GitHub Actions

## Testing
- `pip install -e . --no-deps`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684119ad33848324af9ba248edd3252a